### PR TITLE
No need to SSH onto the box for a restart

### DIFF
--- a/services/nginxplus.md
+++ b/services/nginxplus.md
@@ -42,15 +42,15 @@ Once you have a tunnel open to the active load balancer, you can open up a web b
 1. Check which load balancer is active (see above).
 2. Run the nginx playbook against the non-active load balancer. For example, if `lib-adc1` is active, run the `nginxplus.yml` playbook against `lib-adc2`: `ansible-playbook playbooks/nginxplus.yml --limit lib-adc2.princeton.edu`.
 3. If the playbook fails, fix the failures and run it against the non-active load balancer again, until it succeeds.
-4. SSH to the active load balancer and restart nginx to change which box is active. For example, if  `lib-adc1` is active: `ssh pulsys@lib-adc1.princeton.edu` and from there `$ sudo systemctl restart nginx`. When nginx goes down for the restart, the other box should become active, and the special IP address will be reassigned to it. This may take some time (and possibly a few tries), so check the status before moving on to the next step.
-5. Run the nginx playbook against the second load balancer, the one that was active when you started, and is now non-active.
+   <br /> **Note:** When nginx goes down for the restart, the other box should become active, and the special IP address will be reassigned to it. This may take some time (and possibly a few tries), so check the status before moving on to the next step.
+4. Run the nginx playbook against the second load balancer, the one that was active when you started, and is now non-active.
 
 ### Only upload the new config files
 1. Check which load balancer is active (see above).
 2. Run the nginx playbook against the non-active load balancer. For example, if `lib-adc1` is active, run the `nginxplus.yml` playbook against `lib-adc2`: `ansible-playbook playbooks/nginxplus.yml --limit lib-adc2.princeton.edu -t update_conf`.
 3. If the playbook fails, fix the failures and run it against the non-active load balancer again, until it succeeds.
-4. SSH to the active load balancer and restart nginx to change which box is active. For example, if  `lib-adc1` is active: `ssh pulsys@lib-adc1.princeton.edu` and from there `$ sudo systemctl restart nginx`. When nginx goes down for the restart, the other box should become active, and the special IP address will be reassigned to it. This may take some time (and possibly a few tries), so check the status before moving on to the next step.
-5. Run the nginx playbook against the second load balancer, the one that was active when you started, and is now non-active.
+   <br /> **Note:** When nginx goes down for the restart, the other box should become active, and the special IP address will be reassigned to it. This may take some time (and possibly a few tries), so check the status before moving on to the next step.
+4. Run the nginx playbook against the second load balancer, the one that was active when you started, and is now non-active.
 
 
 ## Updating the load balancers manually


### PR DESCRIPTION
The playbook issues a restart.  There is no need to SSH onto the box for that to occur.