### PR TITLE
Deprecate "Tombstone" and recommend "DeletionMarker"

### DIFF
--- a/norms/inclusive_language.md
+++ b/norms/inclusive_language.md
@@ -25,3 +25,4 @@ The following table includes examples of alternate labels PUL IT has adopted for
 | User testing           | 	Usability testing |
 | Backlog/feature grooming       | 	Backlog/feature refinement |
 | Mob programming/swarming       | 	Ensemble programming |
+| Tombstone              | DeletionMarker |


### PR DESCRIPTION
We want to avoid equating deletion of digital objects to human death.
See notes from cross-team meeting on 1/6/2024 for more background.
