### PR TITLE
Add Tower docs

### DIFF
--- a/services/ansible.md
+++ b/services/ansible.md
@@ -1,14 +1,16 @@
 # About Ansible
 
-Ansible is configuration management tool and remote orchestration tool. It can get the managed endpoint to a desired state, but it can also run shell commands (avoid this and look for modules).
+Ansible is a configuration management and remote orchestration tool. It can get the managed endpoint to a desired state, but it can also run shell commands (avoid this and look for modules).
 
-Ansible is broken down into three major parts. Inventory, Playbooks, and Roles. More information is available running `ansible-doc` command or checkout [the docs](http://docs.ansible.com/modules.html).
+Command-line Ansible is broken down into three major parts. Inventory, Playbooks, and Roles. Our Ansible inventory, playbooks, roles, and conventions live in our [princeton_ansible repository](https://github.com/pulibrary/princeton_ansible).
+
+You can run an Ansible playbook at the command line or in the PUL installation of [Ansible Tower](https://ansible-tower.princeton.edu). For more details on working in our Ansible Tower instance, see [our Tower documentation](./tower.md).
 
 ## Inventory
 
-An inventory is a document that describes all of the hosts you want to manage, and how they are grouped. Take a look at our [master inventory](https://github.com/pulibrary/princeton_ansible/blob/master/hosts) to get a sense of the structure.
+Inventory describes all of the hosts you want to manage, and how they are grouped. Take a look at our [master inventory directory](https://github.com/pulibrary/princeton_ansible/blob/master/inventory) to get a sense of the structure we use.
 
-This allows us to manage individual groups or all boxes. This allows us to address each group of machines separately.
+Using inventory, groups, and other patterns, we can manage anything from an individual box to a group of machines related to a single project to all machines in an environment (staging, production).
 
 ## Roles
 
@@ -16,11 +18,11 @@ From the ansible glossary, "Roles are units of organization in Ansible". This ca
 
 ## Playbooks
 
-Playbook bind it all together. In a playbooks you assign a number of roles to an inventory group, or host. Most of the time you are running playbooks to actually make things happen.
+Playbooks bind it all together. A playbook defines the tasks and/or roles to run and the host or group to run against. Most of the time you are running playbooks to actually make things happen.
 
 ## Vars
 
-We organize vars roughly by
+Variables define the values that change from one machine to another (for example, hostnames, ports, or versions. Our ansible repository organizes vars roughly by
 
 - Common vars
 - Application (global)
@@ -28,7 +30,5 @@ We organize vars roughly by
 - Application (Per-Env)
 - Role
 
-So, if you need to define vars, try and think about them be organized that way.
-
 # How we use Ansible
-If you need to make a change to how ansible works, you commit changes to the [ansible](https://github.com/pulibrary/princeton_ansible) repo, and after a review it is merged for general use
+If you need to make a change to how ansible works, you commit changes to the [ansible](https://github.com/pulibrary/princeton_ansible) repo, and after a review it is merged for general use.

--- a/services/tower.md
+++ b/services/tower.md
@@ -10,46 +10,59 @@ The idle timeout is currently set to 6 hours. When you log out (or get logged ou
 
 ## Ansible Tower Components
 
-To run automation in Ansible Tower you need:
+The main components of automation in Ansible Tower are:
   - an Organization
   - a Project (corresponding to a code repository)
   - an Inventory (corresponding to an inventory file or directory)
-  - a Template (corresponding to a playbook)
+  - one or more Templates (each corresponding to a playbook)
   - one or more Credentials
 
 ### Organizations in PUL Tower
 
 We only have one organization in Tower. It's called Default. Every object we use in Tower MUST belong to the Default organization.
 
-The Organization contains all permissions for other Tower objects. Tower does not force you to select an Organization for every object (for example, Templates or Inventories) but if you do not select the Default Organization for your object, it will not be covered by the permissions of the Organization and no-one will be able to use it.
+The Organization contains all permissions for other Tower objects. Tower does not force you to select an Organization for every object (for example, you can create a template or inventory that does not belong to any organization). However, if you do not select the Default Organization for your object, it will not be covered by the permissions of the Organization and no-one will be able to use it.
 
 ### Projects in PUL Tower
 
 We only have one project in Tower. It's called Princeton Ansible and it is linked to the princeton_ansible repo on GitHub.
 
-The Princeton Ansible project automatically updates daily overnight, deleting the entire repository and cloning a fresh copy from GitHub. If you are running a Template from a branch, Tower automatically pulls the latest commits on that branch before it executes. You can also update the project manually by going to the Projects page and clicking the 'Sync Project' buttons (a circular pair of arrows) to the right of the Princeton Ansible project listing. This starts a Source Control Update job. You must sync the project if you need to pull in a branch with a force-push on it.
+#### Updating the Princeton Ansible project
+
+The Princeton Ansible project automatically updates daily in the early morning hours, deleting the entire repository and cloning a fresh copy from GitHub. If you are running a Template from a branch, Tower automatically pulls the latest commits on that branch before it executes. You can also update the project manually.
+
+** You must sync the project manually to pull in any branch that has had a force-push to it.**
+
+To update the Princeton Ansible project manually:
+1. Select the Projects page
+2. Click the 'Sync Project' button (a circular pair of arrows) on the right under 'Actions'. This starts a Source Control Update job.
+3. Select Jobs from the left navigation and make sure the job succeeds.
 
 ### Inventories in PUL Tower
 
-We only have one inventory in Tower. It's called Princeton Ansible and it is 
+We only have one inventory in Tower. It's called Princeton Ansible and it is linked to the 'inventory' directory of the princeton_ansible repo on GitHub.
 
-## Managing the Ansible Tower service:
+#### Updating the Princeton Ansible inventory
+
+The Princeton Ansible inventory does not automatically update. When you add new machines or groups to the inventory directory on GitHub, you must first update the Princeton Ansible project, then separately update the Princeton Ansible inventory.
+
+To update the Princeton Ansible inventory:
+1. Make sure the Project has already been updated.
+2. Select Inventories from the left navigation.
+3. Select the Princeton Ansible Inventory.
+4. Select the Sources tab.
+5. Click on the 'Start Sync Process' button (a circular pair of arrows) on the right under 'Actions'. This kicks off an Inventory Sync job.
+6.  Select Jobs from the left navigation and make sure the job succeeds.
+
+## Adding templates to tower
+
+You cannot build a template off a playbook until that playbook exists in the main branch – in other words, you can’t test a playbook in Tower Template while it’s still in a PR or on a branch.
+
+All templates should include the Vault credential. Remember that you have to select the credential TYPE first, then the specific credential.
+
+## Managing the Ansible Tower VM/service:
 
 The VM for Tower is 'ansible-tower1'.
 The service is called 'automation-controller'.
 The working directories are in '/var/lib/awx/'.
 
-## Adding templates to tower
-
-When adding an inventory, you can set the “Source” to be a directory, but Tower really tries to make you select a file from the drop-down. I had to hand-enter the path, followed by a space, then click on “Set the source to <path/you/entered>”.
-To allow jobs to use any branch:
-1.	In the Project config:
-a.	Check “Allow branch override”
-2.	In the Job Template config:
-a.	set “Prompt on launch” for the Source Control Branch
-b.	you can enter a branch name as well – if you do, it becomes the default branch for the template, and the “prompt” gives users the ability to override it
-
-
-You cannot build a template off a playbook until that playbook exists in the main branch – in other words, you can’t test a playbook AS A template while it’s in a PR.
-
-All templates should include the Vault credential. Remember that you have to select the credential TYPE first, then the specific credential.

--- a/services/tower.md
+++ b/services/tower.md
@@ -1,6 +1,6 @@
 # About Ansible Tower
 
-Ansible Tower is a GUI-based service for running Ansible playbooks. It stores playbook output for asynchronous debugging, is accessible from outside the VPN, and connects to both Slack and GitHub to support cross-team communication.
+Ansible Tower (aka Controller) is a GUI-based service for running Ansible playbooks. It stores playbook output for asynchronous debugging, is accessible from outside the VPN, and connects to both Slack and GitHub to support cross-team communication.
 
 ## Authenticating to Ansible Tower
 
@@ -19,17 +19,19 @@ The main components of automation in Ansible Tower are:
 
 ### Organizations in PUL Tower
 
-We only have one organization in Tower. It's called Default. Every object we use in Tower MUST belong to the Default organization.
+We only have one organization in Tower. It's called DevOps. Every object we use in Tower MUST belong to the DevOps organization.
 
-The Organization contains all permissions for other Tower objects. Tower does not force you to select an Organization for every object (for example, you can create a template or inventory that does not belong to any organization). However, if you do not select the Default Organization for your object, it will not be covered by the permissions of the Organization and no-one will be able to use it.
+The DevOps Organization contains all permissions for other Tower objects. Tower does not force you to select an Organization for every object (for example, you can create a template or inventory that does not belong to any organization). However, if you do not select the DevOps Organization for your object, it will not be covered by the permissions of the Organization and no-one will be able to use it.
 
 ### Projects in PUL Tower
 
-We only have one project in Tower. It's called Princeton Ansible and it is linked to the princeton_ansible repo on GitHub.
+We only have one project in Tower. It's called Princeton Ansible Project and it is linked to the princeton_ansible repo on GitHub.
 
-#### Updating the Princeton Ansible project
+#### Updating the Princeton Ansible Project
 
-The Princeton Ansible project automatically updates daily in the early morning hours, deleting the entire repository and cloning a fresh copy from GitHub. If you are running a Template from a branch, Tower automatically pulls the latest commits on that branch before it executes. You can also update the project manually.
+The Princeton Ansible project automatically updates daily in the early morning hours, deleting the entire repository and cloning a fresh copy from GitHub. This automatic update is configured in Schedules.
+
+If you are running a Template from a branch, Tower automatically pulls the latest commits on that branch before it executes. You can also update the project manually.
 
 ** You must sync the project manually to pull in any branch that has had a force-push to it.**
 
@@ -40,14 +42,14 @@ To update the Princeton Ansible project manually:
 
 ### Inventories in PUL Tower
 
-We only have one inventory in Tower. It's called Princeton Ansible and it is linked to the 'inventory' directory of the princeton_ansible repo on GitHub.
+We only have one inventory in Tower. It's called Princeton Ansible Inventory and it is linked to the 'inventory' directory of the princeton_ansible repo on GitHub.
 
 #### Updating the Princeton Ansible inventory
 
 The Princeton Ansible inventory does not automatically update. When you add new machines or groups to the inventory directory on GitHub, you must first update the Princeton Ansible project, then separately update the Princeton Ansible inventory.
 
 To update the Princeton Ansible inventory:
-1. Make sure the Project has already been updated.
+1. Make sure the Princeton Ansible project has already been updated.
 2. Select Inventories from the left navigation.
 3. Select the Princeton Ansible Inventory.
 4. Select the Sources tab.
@@ -56,13 +58,18 @@ To update the Princeton Ansible inventory:
 
 ## Adding templates to tower
 
-You cannot build a template off a playbook until that playbook exists in the main branch – in other words, you can’t test a playbook in Tower Template while it’s still in a PR or on a branch.
+You cannot build a template off a playbook until that playbook exists in the main branch. In other words, you cannot test a playbook in a Tower Template while it only exists in a PR or on a branch. If you want to test a playbook from Tower:
+1. Merge a minimal version of the playbook into the main branch.
+2. Update the Princeton Ansible project.
+3. Update the Princeton Ansible inventory.
+4. Create a Template based on the minimal playbook and set Source Control Branch to 'Prompt on launch'.
+5. Create a new branch for changes to the playbook.
+6. Launch the template and select the new branch to run with the latest changes to the branch.
 
-All templates should include the Vault credential. Remember that you have to select the credential TYPE first, then the specific credential.
+All templates must include the Princeton Ansible Vault credential. Most templates also need the VM SSH Connections credential. When you add credentials to a template, you must add them one at a time. Select the credential TYPE (Vault for the Vault cred, Machine for the SSH cred) first, then the specific credential.
 
 ## Managing the Ansible Tower VM/service:
 
 The VM for Tower is 'ansible-tower1'.
 The service is called 'automation-controller'.
 The working directories are in '/var/lib/awx/'.
-

--- a/services/tower.md
+++ b/services/tower.md
@@ -1,0 +1,55 @@
+# About Ansible Tower
+
+Ansible Tower is a GUI-based service for running Ansible playbooks. It stores playbook output for asynchronous debugging, is accessible from outside the VPN, and connects to both Slack and GitHub to support cross-team communication.
+
+## Authenticating to Ansible Tower
+
+You can log into the [PUL Tower installation](https://ansible-tower.princeton.edu) with your Princeton credentials. The system should automatically route you to the SSO login screen and then, once you authenticate, to the main dashboard. If you do not see any data in the dashboard, contact the Library IT Operations team (in the #operations channel on Slack) for enhanced access.
+
+The idle timeout is currently set to 6 hours. When you log out (or get logged out), you will see the non-SSO login screen: https://ansible-tower.princeton.edu/#/login.  For the 'admin' login instead of SSO, use this non-SSO login screen. To return to the SSO login screen, click on the avatar icon ('head and shoulders') at the bottom of the page.
+
+## Ansible Tower Components
+
+To run automation in Ansible Tower you need:
+  - an Organization
+  - a Project (corresponding to a code repository)
+  - an Inventory (corresponding to an inventory file or directory)
+  - a Template (corresponding to a playbook)
+  - one or more Credentials
+
+### Organizations in PUL Tower
+
+We only have one organization in Tower. It's called Default. Every object we use in Tower MUST belong to the Default organization.
+
+The Organization contains all permissions for other Tower objects. Tower does not force you to select an Organization for every object (for example, Templates or Inventories) but if you do not select the Default Organization for your object, it will not be covered by the permissions of the Organization and no-one will be able to use it.
+
+### Projects in PUL Tower
+
+We only have one project in Tower. It's called Princeton Ansible and it is linked to the princeton_ansible repo on GitHub.
+
+The Princeton Ansible project automatically updates daily overnight, deleting the entire repository and cloning a fresh copy from GitHub. If you are running a Template from a branch, Tower automatically pulls the latest commits on that branch before it executes. You can also update the project manually by going to the Projects page and clicking the 'Sync Project' buttons (a circular pair of arrows) to the right of the Princeton Ansible project listing. This starts a Source Control Update job. You must sync the project if you need to pull in a branch with a force-push on it.
+
+### Inventories in PUL Tower
+
+We only have one inventory in Tower. It's called Princeton Ansible and it is 
+
+## Managing the Ansible Tower service:
+
+The VM for Tower is 'ansible-tower1'.
+The service is called 'automation-controller'.
+The working directories are in '/var/lib/awx/'.
+
+## Adding templates to tower
+
+When adding an inventory, you can set the “Source” to be a directory, but Tower really tries to make you select a file from the drop-down. I had to hand-enter the path, followed by a space, then click on “Set the source to <path/you/entered>”.
+To allow jobs to use any branch:
+1.	In the Project config:
+a.	Check “Allow branch override”
+2.	In the Job Template config:
+a.	set “Prompt on launch” for the Source Control Branch
+b.	you can enter a branch name as well – if you do, it becomes the default branch for the template, and the “prompt” gives users the ability to override it
+
+
+You cannot build a template off a playbook until that playbook exists in the main branch – in other words, you can’t test a playbook AS A template while it’s in a PR.
+
+All templates should include the Vault credential. Remember that you have to select the credential TYPE first, then the specific credential.


### PR DESCRIPTION
First round of documentation about Ansible Tower. This PR:
- Updates the documentation about Ansible.
- Adds a page of documentation about Tower, including
  - updating a project
  - updating an inventory
  - Tower testing for playbooks under development

Still to do:
- Document creating a Template in more detail, including how to add and enable Surveys. 
- Gather feedback, document other tasks as needed.