### PR TITLE
[curriculum] Remove XmlHttpRequest

### DIFF
--- a/training-curriculum/javascript.md
+++ b/training-curriculum/javascript.md
@@ -17,8 +17,6 @@
 * [Javascript and the DOM treehouse course](https://teamtreehouse.com/library/javascript-and-the-dom-3)
 * [Interacting with the DOM treehouse course](https://teamtreehouse.com/library/interacting-with-the-dom)
 * [Object-Oriented Javascript treehouse course](https://teamtreehouse.com/library/objectoriented-javascript-2)
-* [AJAX basics treehouse course](https://teamtreehouse.com/library/ajax-basics-2)
-    * [The fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) replaces XMLHTTPRequest
 * [Asynchronous programming with Javascript treehouse video](https://teamtreehouse.com/library/asynchronous-programming-with-javascript)
 * [Working with the fetch api treehouse video](https://teamtreehouse.com/library/working-with-the-fetch-api)
 * [Introduction to front end performance optimization treehouse video](https://teamtreehouse.com/library/introduction-to-front-end-performance-optimization)


### PR DESCRIPTION
Using fetch is preferred over XmlHttpRequest.  Fetch is covered later in the curriculum, and the XmlHttpRequest is quite long.