### PR TITLE
docs on certs not on the LB

### DIFF
--- a/services/create_ssl_certs.md
+++ b/services/create_ssl_certs.md
@@ -14,17 +14,104 @@
 3. Your TLS/SSL cert will be created and returned to you via a email within 3 hours from gandi.net
 4. Verify the files you get back and add them to your server configuration.
 
+## Verifying certbot certificate renewals
+To verify that a certificate on a server will auto-renew:
+
+sudo certbot --standalone --non-interactive --agree-tos --email simonlee@princeton.edu --server https://acme.sectigo.com/v2/InCommonRSAOV --eab-kid  <certbot-key-eab-kid> --eab-hmac-key <certbot-key-eab-hmac-key> renew --dry-run
+
+This command checks all certs that certbot knows about on that server.
+
 ## Manually managed certs list
 
-These certs are for sites we do not serve from the load balancers. These certs must be renewed and deployed manually.
+These certs are not managed by our usual process. These certs cover:
+- sites we do not serve from the load balancers
+- sites without the '.princeton.edu' extension
+- vendor-hosted sites with the '.princeton.edu' extension
+Many of these certs must be deployed manually. Some must also be renewed manually. If a private key is kept in princeton_ansible, it is encrypted as a file in the `/keys/` directory of the repo.
 
 cicognara.org
+Purpose: public site for the Cicognara collection (a collaborative project)
+Managed: on gandi.net, private key is in princeton_ansible
+Deployed: on the load balancers
+
 dataspace.princeton.edu
+
+dataspace-dev.princeton.edu
+Purpose: dev/staging site for dspace
+Managed: in ServiceNow, private key is on princeton_ansible
+Deployed: on Google cloud, on dev.pulcloud.io
+
 dataspace-staging.princeton.edu
+
+dss2.princeton.edu
+Purpose: secures dataset downloads from a separate server for DSS via a web browser
+Managed: in ServiceNow - John will move to letsencrypt
+Deployed: on the dss2 CentOS VM
+Notes: cannot be a SAN name for the main DSS cert, because we only want to secure this functionality on one machine - can be tricky to maintain because server access requires signing nondisclosure agreements (for protected data)
+
+ezproxy.princeton.edu
+Purpose: allows access to journals by confirming Princeton affiliation
+Managed: on ezproxy-prod1 by letsencrypt
+Deployed: in /etc/letsencrypt/live/ezproxy on the ezproxy-prod1 server
+
+imagecat2.princeton.edu
+Philippe will shut down the server once he has copied whatever we need from it. Once it's gone, we can revoke the cert.
+
+lib-aeon.princeton.edu
+Purpose: redirects traffic to hosted Aeon service at https://princeton.aeon.atlas-sys.com
+Managed: for new site by the vendor
+Deployed: to new site by the vendor
+Notes: We would like to redirect the old URL on the load balancers and power off the old lib-aeon machine, but it still holds the templates for printing Aeon call slips.
+
+lib-gisportal.princeton.edu
+Purpose: for maps (Wangyal)
+Managed: in ServiceNow
+Deployed: in IIS on a physical machine that runs MS HyperV virtualization - cluster of lib-geoserv1 and lib-geoserv2 (not the Lib-Gisportal2 VM) server
+Notes: windows physical machine, you must be an admin on the Windows box, expires 2024/07/30
+
 lib-illsql.princeton.edu
+Purpose: interlibrary loan
+Managed: in ServiceNow
+Deployed: in IIS, on the lib-illiad-new VM
+Notes: Windows VM; cert has a SAN name of lib-illiad.princeton.edu; we hope to migrate this to a hosted platform in 2024
+
+lib-rbrr.princeton.edu
+Purpose: rare books reading room
+Managed: by letsencrypt on lib-rbrr
+Deployed: to a physical server in the reading room - server has an alias of libserv447
+Notes: will be replaced in 2024 by a laptop that does not use the LAN. In the interim we need both this cert and the libserv447 cert.
+
+libserv447.princeton.edu
+Purpose: rare books reading room
+Managed: in ServiceNow
+Deployed: deployed on the lib-rbrr physical machine, see listing for lib-rbrr above
+
+libserv97.princeton.edu
+Purpose: Philippe's test machine, may disappear in 2024
+Managed: in ServiceNow
+Deployed: directly on the libserv97 VM (dev environment)
+
 oar.princeton.edu
+
+oar-dev.princeton.edu
+Purpose: open access repository
+Managed: in ServiceNow, private key is on princeton_ansible
+Deployed: on Google cloud at dev.pulcloud.io
+
 oar-staging.princeton.edu
+Purpose: open access repository
+Managed: in ServiceNow, private key is on princeton_ansible
+Deployed: on Google cloud at staging.pulcloud.io
+
+pulmirror.princeton.edu
+Purpose: distributing Ubuntu packages
+Managed: in ServiceNow, private key is in princeton_ansible
+Deployed: on Google cloud at pulmirror.princeton.edu
+
 tigris.princeton.edu
+Purpose: hosted service for University Records management
+Managed: in ServiceNow, private key is in princeton_ansible
+Deployed: by vendor; to update, email a .pfx file of the cert to support@gimmal.com
 
 ### Detailed instructions for sites outside the Princeton domain
 
@@ -193,4 +280,3 @@ Send the resulting file to the tigris support folks via [the Secure Send Portal]
 
 
 [1] Subject Alternative Names are used when multiple domains share the same certificate as shown ![SAN Example](images/san/san_example.png)
-


### PR DESCRIPTION
Most of our certificates live on the load balancer and get auto-renewed with letsencrypt, but some do not. 

This PR aims to document the "oddball" certs - what they do, how to renew them, how to deploy them. ~~Still very much WIP.~~

Let's get this much merged, we can add as we go.