### PR TITLE
Add a warning to the vpn list instructions

### DIFF
--- a/services/vpn.md
+++ b/services/vpn.md
@@ -19,6 +19,9 @@ under "Palo Alto GLobalProtect Cloud Gateways".
 
 ### Get IPs
 
+Currently, this process does not account for all the possible IPs we may get
+from Global Protect.
+
 1. Copy all the FQDNs from the article above into `services/vpn/ips.txt`,
    deleting any empty lines or headers which aren't URLs.
 1. Run `ruby services/vpn/resolve.rb`


### PR DESCRIPTION
Regine and Anna went through the instructions and found that neither of
our current global protect IPs were in the resulting list. Maybe the
list of domains isn't kept current?