### PR TITLE
[gitmessage] Add commit message specifics

### DIFF
--- a/gitmessage.md
+++ b/gitmessage.md
@@ -6,7 +6,13 @@ update your local copy with any changes that have
 been made to this file.
 
 ```bash
-# 50-character subject line
+# 50-character subject line in this format:
+# [issue number, project, or component] Short description in present tense and imperative mood
+#
+# For example:
+# [#3365] Correct type in documentation 
+# [#2431 bibdata] Update node version to 20.4.1
+# [#130 LuxDatePicker] Show holidays in green
 #
 # 72-character wrapped longer description. This should answer:
 #

--- a/gitmessage.md
+++ b/gitmessage.md
@@ -7,19 +7,23 @@ been made to this file.
 
 ```bash
 # 50-character subject line in this format:
-# [issue number, project, or component] Short description in present tense and imperative mood
+# [optional project, or component] Short description in present tense and imperative mood
 #
 # For example:
-# [#3365] Correct type in documentation 
-# [#2431 bibdata] Update node version to 20.4.1
-# [#130 LuxDatePicker] Show holidays in green
+# Correct typo in documentation
+# [bibdata] Update node version to 20.4.1
+# [LuxDatePicker] Show holidays in green
 #
-# 72-character wrapped longer description. This should answer:
 #
+# 72-character wrapped longer description. This should include:
+#
+# * Issue number reference (e.g. "advances #2431" or "closes pulibrary/figgy#6767")
 # * Why was this change necessary?
 # * How does it address the problem?
 # * Are there any side effects?
-# * PUL Co-authored-by:
+#
+#
+# Uncomment the relevant lines to add co-authors:
 #
 # Co-authored-by: Alicia Cozine <acozine@users.noreply.github.com>
 # Co-authored-by: Anna Headley <hackartisan@users.noreply.github.com>


### PR DESCRIPTION
The [git project recommends using imperative mood](https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/SubmittingPatches?h=v2.36.1#n181) in its own commit messages.