### PR TITLE
Add link text to the team handbook links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 The repository walks you through best practices, culture, and technological corner cases on PU Library. These are the parts that are tricky to fully automate or in some cases not possible to. These are also the shared norms and best practices agreed upon across teams in PUL IT which, because they are shared, do not fit solely into one team's handbook.
 
 Each developer team at PU Library also has its own team handbook:
-- https://github.com/pulibrary/dls-handbook
-- https://github.com/pulibrary/rdss-handbook
-- https://github.com/pulibrary/dacs_handbook
+- [DLS handbook](https://pulibrary.github.io/dls-handbook)
+- [RDSS handbook](https://github.com/pulibrary/rdss-handbook)
+- [DACS handbook](https://pulibrary.github.io/dacs_handbook/)
 
 ## Services
 


### PR DESCRIPTION
Also, update DACS and DLS handbook links to point to the jekyll/ github pages versions.