### PR TITLE
Adds draft docs on configuring authN/authZ for CheckMK

### DIFF
--- a/services/checkmk.md
+++ b/services/checkmk.md
@@ -92,3 +92,4 @@ To set up AuthN and AuthZ on a new CheckMK server:
     - set 'Search in' to 'This connection'
 * In the 'Other' section, at the very bottom, set the 'Sync interval' to '1 days 0 hours 0 mins'
 * Click 'Save and test' at the top
+* Note that new users logging in for the first time must log in twice, and it may take some time before new users who should be admins will get the correct permissions. Once the permissions are assigned, the new admin user can (and someone must) activate the User change that made them an admin.

--- a/services/checkmk.md
+++ b/services/checkmk.md
@@ -20,6 +20,17 @@ On the CheckMK server:
 
 *  You can check the server status with `sudo omd status pulmonitor`
 
+## Source control for CheckMK with git
+
+Our CheckMK servers are set to record all changes as git commits.
+
+* The setting is in Settings . . . General . . . Global Settings in the CheckMK UI.
+* The git repo is in the `/omd/sites/pulmonitor/etc/check_mk` directory on the server. Note that `/omd/sites/pulmonitor` is the home directory of the `pulmonitor` user.
+* To check the git history on the server and see what changes have been made:
+  - `sudo su pulmonitor`
+  - `cd /omd/sites/pulmonitor/etc/check_mk`
+  - `git log`
+
 ## Logs
 On the host:
 * The agent seems to log to `/var/log/syslog`.

--- a/services/checkmk.md
+++ b/services/checkmk.md
@@ -51,13 +51,15 @@ To set the timezone for CheckMK:
 Authentication for CheckMK is connected to the Princeton single sign-on. Authorization is controlled by two Grouper groups in Active Directory.
 
 To set up AuthN and AuthZ on a new CheckMK server: 
-* In the CheckMK UI, go to Setup > Users (use the search if Users does not appear as an option under Setup). In the Related menu, select LDAP & ActiveDirectory.
-* Click on 'Add a connection'
+* Log in as the 'cmkadmin' user
+* In the CheckMK UI, go to Setup > Users (use the search if Users does not appear as an option under Setup).
+* In the Related menu, select LDAP & ActiveDirectory.
+* Click on 'Add connection'
 * In the 'General Properties' section:
   * Add an 'ID' and 'Description' (in staging we used the name 'pu_ldap' and the Description Princeton LDAP)
 * In the 'LDAP Connection' section, set:
     - 'Directory type' to 'Active Directory'
-    - 'Connect' to to 'Manually specify list of LDAP servers'
+    - 'Connect to' to 'Manually specify list of LDAP servers'
     - 'LDAP Server' to 'ldapproxy.princeton.edu'
   * Check the 'Bind credentials' box and enter the Bind DN, which is stored in our password manager (pattern is CN=name,OU=department,OU=People,DC=pu,DC=win,DC=princeton,DC=edu)
   * Set 'Bind password' to 'Explicit' and enter the password (also stored in our password manager) in the box - this is a read-only password for LDAP
@@ -65,6 +67,12 @@ To set up AuthN and AuthZ on a new CheckMK server:
   * Check 'Use SSL'
   * Check 'Response timeout' and set the value to 5 seconds
 * In the 'Users' section: 
+  * For the 'User Base DN', enter 'dc=pu,dc=win,dc=princeton,dc=edu'
+  * For the 'Search scope', select 'Search whole subtree below the base DN'
+  * Check 'Search filter' and enter '(&(objectCategory=Person)(sAMAccountName=*))'
+  * Check 'UserID-attribute' and enter 'sAMAccountName'
+  * Check 'Create users only on login'
+* In the 'Groups' section: 
   * For the 'Group Base DN', enter 'ou=grouper,dc=pu,dc=win,dc=princeton,dc=edu'
   * For the 'Search scope', select 'Search whole subtree below the base DN'
   * Check 'Search filter' and enter '(objectclass=group)'
@@ -73,9 +81,14 @@ To set up AuthN and AuthZ on a new CheckMK server:
   * Check 'Alias'
   * Check 'Authentication Expiration'
   * Check 'Email address'
-  * Check 'Roles' and add two entries:
-    - Set the 'Normal monitoring user' Group DN to 'cn=pu:lib:devops:users,ou=grouper,dc=pu,dc=win,dc=princeton,dc=edu'
-    - Set the 'Administrator' Group DN to 'cn=pu:lib:devops:admins,ou=grouper,dc=pu,dc=win,dc=princeton,dc=edu'
-    - For both roles, set 'Search in' to 'This connection'
-* In the 'Other' section, set the 'Sync interval' to '1 days 0 hours 0 mins'
-  
+  * Check 'Roles', and in the new section that opens:
+    - check 'Normal monitoring user'
+    - click 'Add new element'
+    - set the Group DN to 'cn=pu:lib:devops:users,ou=grouper,dc=pu,dc=win,dc=princeton,dc=edu'
+    - set 'Search in' to 'This connection'
+    - check 'Administrator'
+    - click 'Add new element'
+    - set the Group DN to 'cn=pu:lib:devops:admins,ou=grouper,dc=pu,dc=win,dc=princeton,dc=edu'
+    - set 'Search in' to 'This connection'
+* In the 'Other' section, at the very bottom, set the 'Sync interval' to '1 days 0 hours 0 mins'
+* Click 'Save and test' at the top

--- a/services/checkmk.md
+++ b/services/checkmk.md
@@ -16,6 +16,10 @@ On the CheckMK server:
 * As the 'pulsys' user, do `sudo nc -vz hostname.princeton.edu 6556` to confirm that the agent port is accessible on that host.
 * As the 'pulmonitor' user, run `cmk -R` to restart the checkmk service.
 
+## Checking the CheckMK server status
+
+*  You can check the server status with `sudo omd status pulmonitor`
+
 ## Logs
 On the host:
 * The agent seems to log to `/var/log/syslog`.
@@ -64,6 +68,3 @@ To set up AuthN and AuthZ on a new CheckMK server:
     - For both roles, set 'Search in' to 'This connection'
 * In the 'Other' section, set the 'Sync interval' to '1 days 0 hours 0 mins'
   
-## Checking the CheckMK server status
-
-*  You are able to check the server status with `sudo omd status pulmonitor`

--- a/services/checkmk.md
+++ b/services/checkmk.md
@@ -11,10 +11,10 @@ On a monitored host:
 to verify that the agent is running successfully and see its parameters.
 
 
-
 On the CheckMK server:
 * Switch from the 'pulsys' user to the 'pulmonitor' user (`sudo su - pulmonitor` to run in the new user's environment), then execute `cmk --debug -vvn hostname` to look at the connection to a specific host. 
 * As the 'pulsys' user, do `sudo nc -vz hostname.princeton.edu 6556` to confirm that the agent port is accessible on that host.
+* As the 'pulmonitor' user, run `cmk -R` to restart the checkmk service.
 
 ## Logs
 On the host:
@@ -27,11 +27,43 @@ On the CheckMK server:
 
 We wanted to be able to update the CheckMK timezone to be 'America/NY' so that the times can better coordinate between Slack and CheckMK.
 
-The steps to complete this is the following: 
-* Edited `/opt/omd/sites/pulmonitor/etc/environment`, added `TZ=America/New_York`
+To set the timezone for CheckMK: 
+* Edit `/opt/omd/sites/pulmonitor/etc/environment`, added `TZ=America/New_York`
+* Restart the service with `sudo omd restart pulmonitor`
 
-* Restarted the service with `sudo omd restart pulmonitor`
+## Setting up SSO AuthN/AuthZ
 
+Authentication for CheckMK is connected to the Princeton single sign-on. Authorization is controlled by two Grouper groups in Active Directory.
+
+To set up AuthN and AuthZ on a new CheckMK server: 
+* In the CheckMK UI, go to Setup > Users (use the search if Users does not appear as an option under Setup). In the Related menu, select LDAP & ActiveDirectory.
+* Click on 'Add a connection'
+* In the 'General Properties' section:
+  * Add an 'ID' and 'Description' (in staging we used the name 'pu_ldap' and the Description Princeton LDAP)
+* In the 'LDAP Connection' section, set:
+    - 'Directory type' to 'Active Directory'
+    - 'Connect' to to 'Manually specify list of LDAP servers'
+    - 'LDAP Server' to 'ldapproxy.princeton.edu'
+  * Check the 'Bind credentials' box and enter the Bind DN, which is stored in our password manager (pattern is CN=name,OU=department,OU=People,DC=pu,DC=win,DC=princeton,DC=edu)
+  * Set 'Bind password' to 'Explicit' and enter the password (also stored in our password manager) in the box - this is a read-only password for LDAP
+  * Check 'TCP port' and set the value to 636
+  * Check 'Use SSL'
+  * Check 'Response timeout' and set the value to 5 seconds
+* In the 'Users' section: 
+  * For the 'Group Base DN', enter 'ou=grouper,dc=pu,dc=win,dc=princeton,dc=edu'
+  * For the 'Search scope', select 'Search whole subtree below the base DN'
+  * Check 'Search filter' and enter '(objectclass=group)'
+  * Check 'Member attribute' and enter 'member'
+* In the Attribute Sync Plugins section:
+  * Check 'Alias'
+  * Check 'Authentication Expiration'
+  * Check 'Email address'
+  * Check 'Roles' and add two entries:
+    - Set the 'Normal monitoring user' Group DN to 'cn=pu:lib:devops:users,ou=grouper,dc=pu,dc=win,dc=princeton,dc=edu'
+    - Set the 'Administrator' Group DN to 'cn=pu:lib:devops:admins,ou=grouper,dc=pu,dc=win,dc=princeton,dc=edu'
+    - For both roles, set 'Search in' to 'This connection'
+* In the 'Other' section, set the 'Sync interval' to '1 days 0 hours 0 mins'
+  
 ## Checking the CheckMK server status
 
 *  You are able to check the server status with `sudo omd status pulmonitor`


### PR DESCRIPTION
Part of clearing our path to production for CheckMK.

Documents how to set up the LDAP connection between CheckMK and the campus LDAP system. Also adds documentation about the git repo and the quick command for restarting the server.