### PR TITLE
adds info on revoking certs, reorganizes

### DIFF
--- a/services/create_ssl_certs.md
+++ b/services/create_ssl_certs.md
@@ -1,29 +1,34 @@
 # Certificate Management
 
-## Creating TLS Certificates
+## Managing TLS Certificates for sites on our load balancers
+Most of our sites are served from our load balancers - any site that is configured by a file in the `nginxplus` role in princeton_ansible is served from the load balancers.
 
-### For sites on the .princeton.edu domain
-1. You can create auto-renewing certificates and keys directly on the load balancers for sites in the .princeton.edu domain. You can create a single certificate and key with [playbooks/incommon_certbot.yml](https://github.com/pulibrary/princeton_ansible/blob/main/playbooks/incommon_certbot.yml) or create a single certificate with multiple names and keys with [playbooks/incommon_certbot_multi.yml](https://github.com/pulibrary/princeton_ansible/blob/main/playbooks/incommon_certbot_multi.yml)
+### Creating certificates for sites on our load balancers
+1. You can create auto-renewing certificates and keys directly on the load balancers for these sites. You can create a single certificate and key with [playbooks/incommon_certbot.yml](https://github.com/pulibrary/princeton_ansible/blob/main/playbooks/incommon_certbot.yml) or create a single certificate with multiple names and keys with [playbooks/incommon_certbot_multi.yml](https://github.com/pulibrary/princeton_ansible/blob/main/playbooks/incommon_certbot_multi.yml)
 
    1. You will need to run the above playbook on each load balancer sequentially
    1. If the certificate already exists you will need to revoke it before running your chosen playbook
 
-### For sites outside the Princeton domain
-1. Create the CSR (certificate signing request) - can be automated with [playbooks/cert_renewal.yml](https://github.com/pulibrary/princeton_ansible/blob/main/playbooks/incommon_certbot.yml)
-2. Submit it to gandi via [this form](https://shop.gandi.net/en/certificate/create)
-3. Your TLS/SSL cert will be created and returned to you via a email within 3 hours from gandi.net
-4. Verify the files you get back and add them to your server configuration.
+### Revoking certificates for sites on our load balancers
+There is a [ServiceNow form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=2e7ffb64dbad9114e8c283aa13961993) for revoking certificates. You can search in the dropdown by certificate ID or by site name. Note that the site name search only matches the full name - for example, to match `lib-aeon.princeton.edu` you must type `lib-aeon`; if you type `aeon` it will say there are no matching entries.
 
-## Manually managed certs list
+Select the certificate you want to revoke (remember each site on the load balancers has two certs, one for each load balancer), enter a reason, and hit Submit. The process is very quick - refresh the form to confirm that the revoked certificate is no longer listed.
 
-These certs are for sites we do not serve from the load balancers. These certs must be renewed and deployed manually.
+## Managing TLS certificates for sites that do not run on our load balancer
+We have a few sites that we do not serve from the load balancers. The certs for these sites must be renewed and deployed manually. Here is the current list:
 
 cicognara.org
 dataspace-staging.princeton.edu
 lib-illsql.princeton.edu
 oar-staging.princeton.edu
 
-### Detailed instructions for sites outside the Princeton domain
+### Creating certificates for sites that do not run on our load balancers
+1. Create the CSR (certificate signing request) - can be automated with [playbooks/cert_renewal.yml](https://github.com/pulibrary/princeton_ansible/blob/main/playbooks/incommon_certbot.yml)
+2. Submit it to gandi via [this form](https://shop.gandi.net/en/certificate/create)
+3. Your TLS/SSL cert will be created and returned to you via a email within 3 hours from gandi.net
+4. Verify the files you get back and add them to your server configuration.
+
+### Detailed instructions for sites that do not run on our load balancers
 
 #### 1. Create the Certificate Signing Request
 
@@ -172,3 +177,5 @@ Submit the CSR to gandi.net. Use the following guidance:
 
 [1] Subject Alternative Names are used when multiple domains share the same certificate as shown ![SAN Example](images/san/san_example.png)
 
+### Revoking certificates for sites that do not run on our load balancers
+As long as the site has the `.princeton.edu` extension, you can use the [ServiceNow form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=2e7ffb64dbad9114e8c283aa13961993) to revoke its certificates. See the instructions in the section about sites on the load balancers for more details.


### PR DESCRIPTION
This PR adds a section on revoking TLS certificates, with a link to the ServiceNow form.

Once we migrate the cicognara content, will all of our sites and certs have the .princeton.edu extension? Can we simplify the docs then?