### PR TITLE
adds some details to the 'build an EE' step in the Tower documentation

### DIFF
--- a/services/tower.md
+++ b/services/tower.md
@@ -87,11 +87,12 @@ Our custom EEs are built from the YAML files in the ``tower_ees`` directory of t
   * Log into an x86-architected machine (NOT a Mac laptop with an M-series chip) or have a solution for building x86-architected containers on your M-series Mac. If you build on an M-series chip without a solution, the resulting image will fail to load on Tower with the error ``image platform (linux/arm64) does not match the expected platform (linux/amd64)``.
   * Open the princeton_ansible repo and change into the tower_ees directory: ``cd tower_ees``
   * Create or Edit an EE definition file as needed: ``vim my-execution-environment.yml``
-  * Run podman.
+  * Run podman-desktop.
   * Run [ansible-builder](https://ansible.readthedocs.io/projects/builder/en/stable/index.html): ``ansible-builder build -v3 -f my-execution-environment.yml -t <TagOrNameOfEE> --squash all``
   * Note the hash of the built image in the output of the ansible-builder command.
   * Authenticate to quay.io. For easy authN, create a ~/.config/containers/auth.json file with the top level items ‘auths’ and an entry for each container registry you want to use. Each entry contains a key/value pair: the key is “auth” and the value is the output of “echo -n ‘username:password’ | openssl base64”. See [this PR](https://github.com/containers/image/pull/821/files) and [this superuser post](https://superuser.com/questions/120796/how-to-encode-base64-via-command-line) for more details. To authenticate from the command line: ``podman login quay.io``
-  * Push the new image to quay.io: ``podman push <hash-of-image-ID> quay.io/pulibrary/<name-of-image>:<image-tag>``
+  * Push the new image to quay.io: ``podman push <hash-of-image-ID> quay.io/pulibrary/<name-of-image>:<image-tag>``. This command also creates a new repository on quay.io if needed.
+  * If the repository is new, log into quay.io and grant the pulibrary+ansibletower robot user `Read` permissions to it.
   * Create an EE in Tower, or update the existing EE to point to the new tag. For changes to existing EEs, test the Templates that use the EE. If anything fails, reset the EE to pull the previous tag.
 
 ## Managing the Ansible Tower VM/service:


### PR DESCRIPTION
Today @christinach and I built a new execution environment for the Wapiti reports. We followed the documentation here and found a couple of ways to improve it for next time.
