### PR TITLE
Expand network migration docs

### DIFF
--- a/services/private_network.md
+++ b/services/private_network.md
@@ -103,7 +103,7 @@ Our loadbalancer setup consists of the following possible configurations:
       style project_space fill:#fff,stroke:#000,stroke-width:0px
 
             subgraph "Production LBs lib-adc{1,2}.princeton.edu]"
-               SG1[["Configuration files in /usr/share/nginx/html"]]-->B(["Production VMs `mithril-prod{1,2}.princeton.edu`"])
+               SG1[["Configuration files in /usr/share/nginx/html"]]-->B(["Production VMs mithril-prod{1,2}.princeton.edu"])
             end
 
             subgraph "Staging LBs adc-dev{1,2}.lib.princeton.edu]]"

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -17,7 +17,7 @@ This guide describes the migration of a fictional brownfield staging application
 The fictional site is called `mithril-staging.princeton.edu`. It's a fairly typcial staging site. Before the migration begins, the site has:
   * An alias configured on our production loadbalancers as mithril-staging.princeton.edu
   * Two VMs called `mithril-staging1.princeton.edu` and `mithril-staging2.princeton.edu` 
-  * An nginxplus upstream configuration file in `roles/nginxplus/files/conf/http/mithril_staging.conf`
+  * An nginxplus upstream configuration file in `roles/nginxplus/files/conf/http/mithril-staging.conf`
   * Pointers in that configuration file to the two VMs:
     ```conf
     upstream mithril-staging {
@@ -29,7 +29,7 @@ The fictional site is called `mithril-staging.princeton.edu`. It's a fairly typc
 
 ### Migrating IPs to the private network
 
-To migrate a VM's IP address from a publicly routable IP (usually 128.112.x) to an IP on our private network (usually 10.0.x):
+To migrate a VM's IP address from a publicly routable IP (usually 128.112.x) to an IP on our private network (usually 172.20.x):
 
 Use the [Network Record - Modify form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=b28546e14f09ab4818ddd48e5210c756) to request a new IP address for each VM.
 1. Select the Device - for example, `mithril-staging1.princeton.edu`
@@ -38,7 +38,12 @@ Use the [Network Record - Modify form](https://princeton.service-now.com/service
 4. Under 'IPv4 requiring network change' select the IP/MAC address (there will only be one)
 5. Under 'New Network' select `ip4-library-servers`
 6. Click Submit
-This creates a ticket in ServiceNow, and you should receive the usual ServiceNow updates.
+
+This creates a ticket in ServiceNow, and you should receive the usual ServiceNow updates. Note both the old and the new IP addresses.
+
+* In vSphere, edit the VM's settings and switch the Network Adapter to VM Network - LibNet
+* Reboot the VM.
+* Delete all firewall rules related to the old IP address, since the IP will likely be re-used for another system or service.
 
 ### Migrating VM FQDNs to the .lib domain
 
@@ -46,11 +51,18 @@ We use two kinds of FQDNs in common library tasks: sites and VMs. For example, `
 
 NOTE: Migrating existing VMs does involve some downtime. If you want to avoid downtime, create new VMs instead. Be sure to give them the `.lib.princeton.edu` extension (in vSphere and in DNS) and to request IPs in the private IP space (the `ip4-library-servers` network).
 
-For example, to migrate `mithril_staging1.princeton.edu` to `mithril_staging1.lib.princeton.edu`:
+* Either change the DNS record for the FQDN of each existing VM, or create new VMs in the `.lib` domain (make sure they have IPs in the private network if you do!). To transfer `mithril-staging1.princeton.edu` to `mithril-staging1.lib.princeton.edu`:
 
-* Either [transfer the network registration](https://networkregistration.princeton.edu) for the FQDN of each existing VM, or create new VMs in the `.lib` domain. For example, we must transfer `mithril-staging1.princeton.edu` to `mithril-staging1.lib.princeton.edu`.
-  * If you transferred existing VMs, change the VM names in vSphere.
-  * If you created new VMs, run the application build playbook on your new application servers to set them up. Where applicable run capistrano to update your new application.
+Use the [Network Record - Modify form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=b28546e14f09ab4818ddd48e5210c756) to request a new IP address for each VM.
+1. Select the Device - for example, `mithril-staging1.princeton.edu`
+2. Under 'What would you like to modify?' select `Wired static IP`
+3. Select the Host (there will only be one) and check 'Modify Device Name'
+4. Under 'Device record' set 'DNS Domain Zone' to `lib.princeton.edu` and set 'Device Name' to `mithril-staging1` - the combination of these two settings will get you `mithril-staging1.princeton.edu`. 
+6. Click Submit.
+
+This creates a ticket in ServiceNow, and you should receive the usual ServiceNow updates.
+
+* If you created new VMs, run the application build playbook and do anything else you need to do (capistrano deploy, etc.) to set them up.
 * Update the nginxplus config to point to the VMs in the .lib domain (transferred or new):
   ```conf
   upstream mithril-staging {
@@ -60,7 +72,7 @@ For example, to migrate `mithril_staging1.princeton.edu` to `mithril_staging1.li
     server mithril-staging2.lib.princeton.edu resolve;
   ```
 * Run the nginxplus playbook to deploy the config changes.
-* If you created new VMs, decommission the old one VMs.
+* If you created new VMs, decommission the old VMs with all firewall rules, etc.
 
 ### Migrating staging sites to the staging load balancers
 
@@ -76,11 +88,12 @@ To migrate a staging site to the new staging load balancers:
 * Create SSL certificates on the dev loadbalancers by running the [Incommon Certificates](playbooks/incommon_certbot.yml) on the dev loadbalancers
   * Run `ansible-playbook -v -e domain_name=mithril-staging --limit adc-dev2.lib.princeton.edu playbooks/incommon_certbot.yml`
   * Repeat on adc-dev1.lib.princeton.edu
-* Move the site's nginxplus config file from `roles/nginxplus/files/conf/http/mithril_staging.conf` to `roles/nginxplus/files/conf/http/dev/mithril_staging.conf`
+* Update the cache definition in the site's nginxplus config to point to `/var/cache/nginx/<site-name>/` (on the prod LBs the caches are in `/data/nginx/<site-name>/NGINX_cache`)
+* Move the site's nginxplus config file from `roles/nginxplus/files/conf/http/mithril-staging.conf` to `roles/nginxplus/files/conf/http/dev/mithril-staging.conf`
 * Run the nginxplus playbook on all four loadbalancers (one at a time), to remove the config from production and add it to staging.
 * Revoke the old SSL certificates on the production loadbalancers.
 
-## Princeton loadbalancer setup
+## WIP graph of Princeton loadbalancer setup
 
 Our private network setup consists of the following possible configurations.
 

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -97,6 +97,10 @@ Our loadbalancer setup consists of the following possible configurations:
   graph LR;
       S31[/"Production Sites"/]-->SG1
       S33[/"Staging Sites"/]-->SG3
+      subgraph project [" "]
+      subgraph project_space [" "]
+      style project fill:#fff,stroke:#000,stroke-width:4px,color:#000,stroke-dasharray: 5 5
+      style project_space fill:#fff,stroke:#000,stroke-width:0px
 
             subgraph "Production LBs lib-adc{1,2}.princeton.edu]"
                SG1[["Configuration files in /usr/share/nginx/html"]]-->B(["Production VMs `mithril-prod{1,2}.princeton.edu`"])

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -108,8 +108,7 @@ Our loadbalancer setup consists of the following possible configurations:
       style project fill:#fff,stroke:#000,stroke-width:4px,color:#000,stroke-dasharray: 5 5
       style project_space fill:#fff,stroke:#000,stroke-width:0px
 
-            subgraph prod [Production LBs lib-adc{1,2}.princeton.edu]
-            subgraph prod subgraph_padding fill:none, stroke:none
+            subgraph "Production LBs lib-adc{1,2}.princeton.edu]"
                SG1[["Configuration files in /usr/share/nginx/html"]]-->B(["Production VMs mithril-prod{1,2}.princeton.edu"])
             end
 

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -80,7 +80,7 @@ To migrate a staging site to the new staging load balancers:
 * Run the nginxplus playbook on all four loadbalancers (one at a time), to remove the config from production and add it to staging.
 * Revoke the old SSL certificates on the production loadbalancers.
 
-## Princeton Private Network Setup
+## Princeton loadbalancer setup
 
 Our private network setup consists of the following possible configurations.
 

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -1,10 +1,20 @@
 # Private Network Migration
 
-Library IT is migrating VMs to new IPs to take advantage of our new private network. Our Application Delivery Controllers (loadbalancers) are multi-homed on both the private and public networks, so they can connect to servers on the private network. In tandem with this IP migration, we are also moving FQDNs for VMs to our new `.lib` domain and moving staging sites to our new staging load balancers.
+Library IT is migrating VMs to new IPs to take advantage of our private network. Our Application Delivery Controllers (loadbalancers) are multi-homed on both the private and public networks, so they can connect to servers on the private network. In tandem with this IP migration, we are also moving FQDNs for VMs to the `.lib` domain and moving staging sites to our staging load balancers.
+
+By migrating our VMs to IPs on the private network, we improve our security posture, expand our network throughput (because the private network has 10GB capacity, compared to 1GB on the public network), and release scarce publicly routable IPs back to the University.
+
+By migrating VM FQDNs to the .lib domain, we can easily see which VMs have publicly routable IPs and which do not.
+
+By migrating staging sites to the staging load balancers, we free up capacity on the production load balancers and reduce risk to production sites from experimentation on staging sites.
 
 ## Don't Panic
 
-This guide describes the migration of a fictional brownfield staging application. When it's done, the application servers will be on our [private network (RFC 1918)](https://www.rfc-editor.org/rfc/rfc1918), the VMs will be on our `.lib` domain, and the site will be on our staging load balancers. The fictional site is called `mithril-staging.princeton.edu`. It's a fairly typcial staging site. Before the migration begins, the site has:
+This guide describes the migration of a fictional brownfield staging application. When it's done, the application servers will be on our [private network (RFC 1918)](https://www.rfc-editor.org/rfc/rfc1918), the VMs will be on our `.lib` domain, and the site will be on our staging load balancers.
+
+#### Fictional site before the Migration
+
+The fictional site is called `mithril-staging.princeton.edu`. It's a fairly typcial staging site. Before the migration begins, the site has:
   * An alias configured on our production loadbalancers as mithril-staging.princeton.edu
   * Two VMs called `mithril-staging1.princeton.edu` and `mithril-staging2.princeton.edu` 
   * An nginxplus upstream configuration file in `roles/nginxplus/files/conf/http/mithril_staging.conf`
@@ -19,8 +29,6 @@ This guide describes the migration of a fictional brownfield staging application
 
 ### Migrating IPs to the private network
 
-By migrating our VMs to IPs on the private network, we improve our security posture, expand our network throughput (because the private network has 10GB capacity, compared to 1GB on the public network), and release scarce publicly routable IPs back to the University.
-
 To migrate a VM's IP address from a publicly routable IP (usually 128.112.x) to an IP on our private network (usually 10.0.x):
 
 Use the [Network Record - Modify form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=b28546e14f09ab4818ddd48e5210c756) to request a new IP address for each VM.
@@ -33,8 +41,6 @@ Use the [Network Record - Modify form](https://princeton.service-now.com/service
 This creates a ticket in ServiceNow, and you should receive the usual ServiceNow updates.
 
 ### Migrating VM FQDNs to the .lib domain
-
-By migrating VM FQDNs to the .lib domain, we can easily see which VMs are publicly routable and which are not.
 
 We use two kinds of FQDNs in common library tasks: sites and VMs. For example, `mithril-staging.princeton.edu` is a site FQDN; `mithril-staging1.princeton.edu` is a VM FQDN. We can (and probably will) leave all site FQDNs as they are. We do not need to  add `.lib` to site FQDNs - though we can if folks want to!
 
@@ -55,8 +61,6 @@ For example, to migrate `mithril_staging1.princeton.edu` to `mithril_staging1.li
 * Run the nginxplus playbook to deploy the config changes.
 
 ### Migrating staging sites to the staging load balancers
-
-By migrating staging sites to the staging load balancers, we free up capacity on the production load balancers and reduce risk to production sites from experimentation on staging sites.
 
 To migrate a staging site to the new staging load balancers:
 

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -102,11 +102,11 @@ Our loadbalancer setup consists of the following possible configurations:
       style project fill:#fff,stroke:#000,stroke-width:4px,color:#000,stroke-dasharray: 5 5
       style project_space fill:#fff,stroke:#000,stroke-width:0px
 
-            subgraph "Production LBs `lib-adc{1,2}.princeton.edu`]"
+            subgraph "Production LBs lib-adc{1,2}.princeton.edu]"
                SG1[["Configuration files in /usr/share/nginx/html"]]-->B(["Production VMs `mithril-prod{1,2}.princeton.edu`"])
             end
 
-            subgraph "Staging LBs `adc-dev{1,2}.lib.princeton.edu`]]"
+            subgraph "Staging LBs adc-dev{1,2}.lib.princeton.edu]]"
                SG3[["Configuration files in /usr/share/nginx/html"]]-->DE(["Staging VMs: mithril-staging{1,2}.lib.princeton.edu"]);
             end
          

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -91,30 +91,24 @@ To migrate a staging site to the new staging load balancers, the Operations team
 
 ## WIP graph of Princeton loadbalancer setup
 
-Our private network setup consists of the following possible configurations.
+Our loadbalancer setup consists of the following possible configurations:
 
 ```mermaid
   graph LR;
-      S31[/"Production Loadbalancer [configuration file on lib-adc{1,2}.princeton.edu]"/]-->SG1
-      S32[/"QA Loadbalancer [configuration file on lib-adc{1,2}]"/]-->SG2
-      S33[/"Staging Loadbalancer [configuration file on adc-dev{1,2}.lib.princeton.edu]"/]-->SG3
+      S31[/"Production Sites"/]-->SG1
+      S33[/"Staging Sites"/]-->SG3
       subgraph project [" "]
       subgraph project_space [" "]
       style project fill:#fff,stroke:#000,stroke-width:4px,color:#000,stroke-dasharray: 5 5
       style project_space fill:#fff,stroke:#000,stroke-width:0px
 
-            subgraph "PreCuration Globus Endpoint [pdc precuration]]"
-               SG1[[" [pdc s3 storage gateway precuration]"]]-->B(["Pre Curation Collection (private) [Princeton Data Commons * Precuration]"])
+            subgraph "Production LBs `lib-adc{1,2}.princeton.edu`]"
+               SG1[["Configuration files in /usr/share/nginx/html"]]-->B(["Production VMs `mithril-prod{1,2}.princeton.edu`"])
             end
 
-            subgraph "Postcuration Globus Endpoint [pdc postcuration]]"
-               SG2[["Post Curation Storage Gateway [pdc s3 storage gateway postcuration]"]]-->D(["Curation Collection(curator only read/write) [Princeton Data Commons * Postcuration]"]);
+            subgraph "Staging LBs `adc-dev{1,2}.lib.princeton.edu`]]"
+               SG3[["Configuration files in /usr/share/nginx/html"]]-->DE(["Staging VMs: mithril-staging{1,2}.lib.princeton.edu"]);
             end
- 
-            subgraph "Staging Sites on Staging Loadbalancers [adc-dev{1,2}]]"
-               SG3[["Configuration files in /usr/share/nginx/html"]]-->DE(["mithril-staging{1,2}.lib.princeton.edu"]);
-            end
-         
          
       end
    end

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -108,7 +108,8 @@ Our loadbalancer setup consists of the following possible configurations:
       style project fill:#fff,stroke:#000,stroke-width:4px,color:#000,stroke-dasharray: 5 5
       style project_space fill:#fff,stroke:#000,stroke-width:0px
 
-            subgraph "Production LBs lib-adc{1,2}.princeton.edu]"
+            subgraph prod [Production LBs lib-adc{1,2}.princeton.edu]
+            subgraph prod subgraph_padding fill:none, stroke:none
                SG1[["Configuration files in /usr/share/nginx/html"]]-->B(["Production VMs mithril-prod{1,2}.princeton.edu"])
             end
 

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -108,18 +108,22 @@ Our loadbalancer setup consists of the following possible configurations:
       style project fill:#fff,stroke:#000,stroke-width:4px,color:#000,stroke-dasharray: 5 5
       style project_space fill:#fff,stroke:#000,stroke-width:0px
 
-            subgraph "Production LBs lib-adc{1,2}.princeton.edu]"
-               SG1[["Configuration files in /usr/share/nginx/html"]]-->B(["Production VMs mithril-prod{1,2}.princeton.edu"])
+            subgraph "Production LBs lib-adc{1,2}.princeton.edu"
+               subgraph spacer1 [" "]
+               SG1["Configuration files in /usr/share/nginx/html"]-->B(["Production VMs mithril-prod{1,2}.princeton.edu"])
+               end
             end
 
-            subgraph "Staging LBs adc-dev{1,2}.lib.princeton.edu]]"
-               SG3[["Configuration files in /usr/share/nginx/html"]]-->DE(["Staging VMs: mithril-staging{1,2}.lib.princeton.edu"]);
+            subgraph "Staging LBs adc-dev{1,2}.lib.princeton.edu"
+               subgraph spacer2 [" "]
+               SG3["Configuration files in /usr/share/nginx/html"]-->DE(["Staging VMs: mithril-staging{1,2}.lib.princeton.edu"]);
+               end
             end
          
       end
    end
 
-   classDef ecclass fill:#00f,stroke:#00f,stroke-width:0px,color:#fff;
-   class EC2,EC2a,EC2b,ec2_sp,ec2a_sp,ec2b_sp ecclass;
+   classDef fillerclass fill:transparent,stroke:none,color:#fff;
+   class spacer1,spacer2 fillerclass;
 
 ```

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -95,9 +95,9 @@ Our private network setup consists of the following possible configurations.
 
 ```mermaid
   graph LR;
-      S31[/"Production Loadbalancer [configuration file on lib-adc{1,2}]"/]-->SG1
+      S31[/"Production Loadbalancer [configuration file on lib-adc{1,2}.princeton.edu]"/]-->SG1
       S32[/"QA Loadbalancer [configuration file on lib-adc{1,2}]"/]-->SG2
-      S33[/"Staging Loadbalancer [configuration file on adc-dev{1,2}]"/]-->SG3
+      S33[/"Staging Loadbalancer [configuration file on adc-dev{1,2}.lib.princeton.edu]"/]-->SG3
       subgraph project [" "]
       subgraph project_space [" "]
       style project fill:#fff,stroke:#000,stroke-width:4px,color:#000,stroke-dasharray: 5 5
@@ -111,8 +111,8 @@ Our private network setup consists of the following possible configurations.
                SG2[["Post Curation Storage Gateway [pdc s3 storage gateway postcuration]"]]-->D(["Curation Collection(curator only read/write) [Princeton Data Commons * Postcuration]"]);
             end
  
-            subgraph "Deposit Globus Endpoint [pdc deposit]]"
-               SG3[["Deposit Storage Gateway [pdc s3 storage gateway deposit]"]]-->DE(["Curation Collection(curator controlled read/write) [Princeton Data Commons Deposit]"]);
+            subgraph "Staging Sites on Staging Loadbalancers [adc-dev{1,2}]]"
+               SG3[["Configuration files in /usr/share/nginx/html"]]-->DE(["mithril-staging{1,2}.lib.princeton.edu"]);
             end
          
          

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -29,7 +29,7 @@ The fictional site is called `mithril-staging.princeton.edu`. It's a fairly typc
 
 ### Migrating IPs to the private network
 
-To migrate a VM's IP address from a publicly routable IP (usually 128.112.x) to an IP on our private network (usually 172.20.x), the Operations team can use the [Network Record - Modify form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=b28546e14f09ab4818ddd48e5210c756) to request a new IP address for each VM.
+To migrate a VM's IP address from a publicly routable IP (usually 128.112.x) to an IP on our private network (usually 172.20.x), the Operations team can use the [Network Record - Modify form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=b28546e14f09ab4818ddd48e5210c756) to request a new IP address for each VM:
 1. Select the Device - for example, `mithril-staging1.princeton.edu`.
 2. Under 'What would you like to modify?' select `Wired static IP`.
 3. Select the Host (there will only be one) and check 'Add/Modify/Delete MAC Address or Static IP'.
@@ -55,9 +55,7 @@ If you choose to create new VMs:
 * Run the application build playbook to set up your new VMs.
 Once your VMs are If you create new VMs, start the checklist below at number 6 - updating the project's `config/deploy/staging.rb` file.
 
-
-
-To transfer `mithril-staging1.princeton.edu` to `mithril-staging1.lib.princeton.edu`, the Operations team can use the [Network Record - Modify form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=b28546e14f09ab4818ddd48e5210c756) to request a new IP address for each VM.
+To transfer `mithril-staging1.princeton.edu` to `mithril-staging1.lib.princeton.edu`, the Operations team can use the [Network Record - Modify form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=b28546e14f09ab4818ddd48e5210c756) to request a new IP address for each VM:
 1. Select the Device - for example, `mithril-staging1.princeton.edu`.
 2. Under 'What would you like to modify?' select `Wired static IP`.
 3. Select the Host (there will only be one) and check 'Modify Device Name'.
@@ -83,20 +81,19 @@ To transfer `mithril-staging1.princeton.edu` to `mithril-staging1.lib.princeton.
 
 ### Migrating staging sites to the staging load balancers
 
-To migrate a staging site to the new staging load balancers, the Operations team can modify the network registration to transfer the site FQDN `mithril-staging.princeton.edu` from the production loadbalancers to the dev loadbalancers
-1. Use the [network record - modify form](https://networkregistration.princeton.edu).
-2. Select lib-adc.princeton.edu for the Device.
-3. Select Wired static IP records for 'What would you like to modify'.
-4. Select the Host and check 'Add/Modify/Delete alias'.
-5. Scroll down to find the 'Transfer Aliases' section, and enter the site under 'Aliases to transfer to another Host' and select `adc-dev.lib.princeton.edu` under 'Transfer Aliases to'.
-6. Click Submit.
-7. Create SSL certificates on the dev loadbalancers by running the [Incommon Certificates](playbooks/incommon_certbot.yml) on the dev loadbalancers:
+To migrate a staging site to the new staging load balancers, the Operations team can use the [network record - modify form](https://networkregistration.princeton.edu) to transfer the site FQDN `mithril-staging.princeton.edu` from the production loadbalancers to the dev loadbalancers:
+1. Select `lib-adc.princeton.edu` under Device.
+2. Select Wired static IP records for 'What would you like to modify'.
+3. Select the Host and check 'Add/Modify/Delete alias'.
+4. Scroll down to find the 'Transfer Aliases' section, and enter the site under 'Aliases to transfer to another Host' and select `adc-dev.lib.princeton.edu` under 'Transfer Aliases to'.
+5. Click Submit.
+6. Create SSL certificates on the dev loadbalancers by running the [Incommon Certificates](playbooks/incommon_certbot.yml) on the dev loadbalancers:
   * Run `ansible-playbook -v -e domain_name=mithril-staging --limit adc-dev2.lib.princeton.edu playbooks/incommon_certbot.yml`.
   * Repeat on adc-dev1.lib.princeton.edu.
-8. Update the cache definition in the site's nginxplus config to point to `/var/cache/nginx/<site-name>/` (on the prod LBs the caches are in `/data/nginx/<site-name>/NGINX_cache`).
-9. Move the site's nginxplus config file from `roles/nginxplus/files/conf/http/mithril-staging.conf` to `roles/nginxplus/files/conf/http/dev/mithril-staging.conf`.
-10. Run the nginxplus playbook on all four loadbalancers (one at a time), to remove the config from production and add it to staging.
-11. Revoke the old SSL certificates on the production loadbalancers.
+7. Update the cache definition in the site's nginxplus config to point to `/var/cache/nginx/<site-name>/` (on the prod LBs the caches are in `/data/nginx/<site-name>/NGINX_cache`).
+8. Move the site's nginxplus config file from `roles/nginxplus/files/conf/http/mithril-staging.conf` to `roles/nginxplus/files/conf/http/dev/mithril-staging.conf`.
+9. Run the nginxplus playbook on all four loadbalancers (one at a time), to remove the config from production and add it to staging.
+10. Revoke the old SSL certificates on the production loadbalancers.
 
 ## WIP graph of Princeton loadbalancer setup
 

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -72,6 +72,16 @@ This creates a ticket in ServiceNow, and you should receive the usual ServiceNow
     server mithril-staging2.lib.princeton.edu resolve;
   ```
 * Run the nginxplus playbook to deploy the config changes.
+* Update the server definitions in your project's 'config/deploy/staging.rb' file, from
+  ```conf
+  server "mithril-staging1.princeton.edu", user: "deploy", roles: %w[app db web]
+  server "mithril-staging2.princeton.edu", user: "deploy", roles: %w[app db web]
+  ```
+to
+  ```conf
+  server "mithril-staging1.lib.princeton.edu", user: "deploy", roles: %w[app db web]
+  server "mithril-staging2.lib.princeton.edu", user: "deploy", roles: %w[app db web]
+  ```
 * If you created new VMs, decommission the old VMs with all firewall rules, etc.
 
 ### Migrating staging sites to the staging load balancers

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -36,7 +36,7 @@ To migrate a VM's IP address from a publicly routable IP (usually 128.112.x) to 
 4. Under 'IPv4 requiring network change' select the IP/MAC address (there will only be one).
 5. Under 'New Network' select `ip4-library-servers`.
 6. Click Submit. This creates a ticket in ServiceNow, and you should receive the usual ServiceNow updates. Note both the old and the new IP addresses.
-7. In vSphere, edit the VM's settings and switch the 'Network Adapter' to `VM Network - LibNet`.
+7. In vSphere, edit the VM's settings and switch the 'Network Adapter' to `VM Network - ip4-library-servers`.
 8. Reboot the VM so it picks up the new IP address.
 9. Delete all firewall rules related to the old IP address, since the IP will likely be re-used for another system or service.
 
@@ -50,7 +50,7 @@ NOTE: Migrating existing VMs does involve some downtime. If you want to avoid do
 
 If you choose to create new VMs:
 * Give them the `.lib.princeton.edu` extension in DNS.
-* Set the 'Network Adapter' in vSphere to to `VM Network - LibNet`.
+* Set the 'Network Adapter' in vSphere to to `VM Network - ip4-library-servers`.
 * Select the `ip4-library-servers` network when registering them with OIT.
 * Run the application build playbook to set up your new VMs.
 Once your VMs are If you create new VMs, start the checklist below at number 6 - updating the project's `config/deploy/staging.rb` file.

--- a/services/private_network.md
+++ b/services/private_network.md
@@ -97,10 +97,6 @@ Our loadbalancer setup consists of the following possible configurations:
   graph LR;
       S31[/"Production Sites"/]-->SG1
       S33[/"Staging Sites"/]-->SG3
-      subgraph project [" "]
-      subgraph project_space [" "]
-      style project fill:#fff,stroke:#000,stroke-width:4px,color:#000,stroke-dasharray: 5 5
-      style project_space fill:#fff,stroke:#000,stroke-width:0px
 
             subgraph "Production LBs lib-adc{1,2}.princeton.edu]"
                SG1[["Configuration files in /usr/share/nginx/html"]]-->B(["Production VMs `mithril-prod{1,2}.princeton.edu`"])


### PR DESCRIPTION
Builds on #321.

Divides the migration into three phases:
- the private network/IP space
- the .lib domain
- the staging loadbalancers

Provides rationale for each migration step.
Provides separate instructions for each migration step.
