### PR TITLE
adds info on recapgfa SSL cert

### DIFF
--- a/services/create_ssl_certs.md
+++ b/services/create_ssl_certs.md
@@ -111,6 +111,11 @@ Purpose: distributing Ubuntu packages
 Managed: in ServiceNow, private key is in princeton_ansible
 Deployed: on Google cloud at pulmirror.princeton.edu
 
+recapgfa.princeton.edu
+Purpose: ReCAP inventory management system
+Managed: by ACME directly on the VM
+Deployed: N/A - it automatically renews
+
 simrisk.pulcloud.io
 Purpose: experimental application for CDH
 Managed: on staging.pulcloud.io by acme-client contacting letsencrypt CA


### PR DESCRIPTION
Closes https://gitlab.lib.princeton.edu/ops/team-handbook/-/issues/94.

There is a one-off SSL certificate for `recapgfa.princeton.edu` that is hosted and renewed directly on the server (not on our load balancers). 

This PR adds it to our documentation about "oddball" SSL certs. 