### PR TITLE
Format docs on manually-managed SSL certs

### DIFF
--- a/services/create_ssl_certs.md
+++ b/services/create_ssl_certs.md
@@ -31,102 +31,102 @@ These certs are not managed by our usual process. These certs cover:
 - vendor-hosted sites with the '.princeton.edu' extension
 Many of these certs must be deployed manually. Some must also be renewed manually. If a private key is kept in princeton_ansible, it is encrypted as a file in the `/keys/` directory of the repo.
 
-cicognara.org
-Purpose: public site for the Cicognara collection (a collaborative project)
-Managed: [Lego](https://github.com/pulibrary/princeton_ansible/blob/main/roles/nginxplus/tasks/lego.yml)
-Deployed: on the load balancers
+cicognara.org  
+Purpose: public site for the Cicognara collection (a collaborative project)  
+Managed: [Lego](https://github.com/pulibrary/princeton_ansible/blob/main/roles/nginxplus/tasks/lego.yml)  
+Deployed: on the load balancers  
 
-dataspace.princeton.edu
-Purpose: production site for dspace
-Managed: Via [Lego](lego.md)
-Deployed: on Google cloud, on prod.pulcloud.io
+dataspace.princeton.edu  
+Purpose: production site for dspace  
+Managed: Via [Lego](lego.md)  
+Deployed: on Google cloud, on prod.pulcloud.io  
 
-dataspace-dev.princeton.edu
-Purpose: dev/staging site for dspace
-Managed: Via [Lego](lego.md)
-Deployed: on Google cloud, on dev.pulcloud.io
+dataspace-dev.princeton.edu  
+Purpose: dev/staging site for dspace  
+Managed: Via [Lego](lego.md)  
+Deployed: on Google cloud, on dev.pulcloud.io  
 
-dataspace-staging.princeton.edu
-Purpose: dev/staging site for dspace
-Managed: Via [Lego](lego.md)
-Deployed: on Google cloud, on dev.pulcloud.io
+dataspace-staging.princeton.edu  
+Purpose: dev/staging site for dspace  
+Managed: Via [Lego](lego.md)  
+Deployed: on Google cloud, on dev.pulcloud.io  
 
-dss2.princeton.edu
-Purpose: secures dataset downloads from a separate server for DSS via a web browser
-Managed: in ServiceNow - John will move to letsencrypt
-Deployed: on the dss2 CentOS VM
-Notes: cannot be a SAN name for the main DSS cert, because we only want to secure this functionality on one machine - can be tricky to maintain because server access requires signing nondisclosure agreements (for protected data)
+dss2.princeton.edu  
+Purpose: secures dataset downloads from a separate server for DSS via a web browser  
+Managed: in ServiceNow - John will move to letsencrypt  
+Deployed: on the dss2 CentOS VM  
+Notes: cannot be a SAN name for the main DSS cert, because we only want to secure this functionality on one machine - can be tricky to maintain because server access requires signing nondisclosure agreements (for protected data)  
 
-ezproxy.princeton.edu
-Purpose: allows access to journals by confirming Princeton affiliation
-Managed: on ezproxy-prod1 by letsencrypt
-Deployed: in /etc/letsencrypt/live/ezproxy on the ezproxy-prod1 server
+ezproxy.princeton.edu  
+Purpose: allows access to journals by confirming Princeton affiliation  
+Managed: on ezproxy-prod1 by letsencrypt  
+Deployed: in /etc/letsencrypt/live/ezproxy on the ezproxy-prod1 server  
 
-imagecat2.princeton.edu
-Philippe will shut down the server once he has copied whatever we need from it. Once it's gone, we can revoke the cert.
+imagecat2.princeton.edu  
+Philippe will shut down the server once he has copied whatever we need from it. Once it's gone, we can revoke the cert.  
 
-lib-aeon.princeton.edu
-Purpose: redirects traffic to hosted Aeon service at https://princeton.aeon.atlas-sys.com
-Managed: for new site by the vendor
-Deployed: to new site by the vendor
-Notes: We would like to redirect the old URL on the load balancers and power off the old lib-aeon machine. The templates for printing Aeon call slips, which used to live on the lib-aeon machine, have been moved to a fileshare called aeonprint on lib-fileshare.
+lib-aeon.princeton.edu  
+Purpose: redirects traffic to hosted Aeon service at https://princeton.aeon.atlas-sys.com  
+Managed: for new site by the vendor  
+Deployed: to new site by the vendor  
+Notes: We would like to redirect the old URL on the load balancers and power off the old lib-aeon machine. The templates for printing Aeon call slips, which used to live on the lib-aeon machine, have been moved to a fileshare called aeonprint on lib-fileshare.  
 
-lib-gisportal.princeton.edu
-Purpose: for maps (Wangyal)
-Managed: in ServiceNow
-Deployed: in IIS on a physical machine that runs MS HyperV virtualization - cluster of lib-geoserv1 and lib-geoserv2 (not the Lib-Gisportal2 VM) server
-Notes: windows physical machine, you must be an admin on the Windows box, expires 2024/07/30
+lib-gisportal.princeton.edu  
+Purpose: for maps (Wangyal)  
+Managed: in ServiceNow  
+Deployed: in IIS on a physical machine that runs MS HyperV virtualization - cluster of lib-geoserv1 and lib-geoserv2 (not the Lib-Gisportal2 VM) server  
+Notes: windows physical machine, you must be an admin on the Windows box, expires 2024/07/30  
 
-lib-illsql.princeton.edu
-Purpose: interlibrary loan
-Managed: in ServiceNow
-Deployed: in IIS, on the lib-illiad-new VM
-Notes: Windows VM; cert has a SAN name of lib-illiad.princeton.edu; we hope to migrate this to a hosted platform in 2024
+lib-illsql.princeton.edu  
+Purpose: interlibrary loan  
+Managed: in ServiceNow  
+Deployed: in IIS, on the lib-illiad-new VM  
+Notes: Windows VM; cert has a SAN name of lib-illiad.princeton.edu; we hope to migrate this to a hosted platform in 2024  
 
-libserv97.princeton.edu
-Purpose: Philippe's test machine, may disappear in 2024
-Managed: in ServiceNow
-Deployed: directly on the libserv97 VM (dev environment)
+libserv97.princeton.edu  
+Purpose: Philippe's test machine, may disappear in 2024  
+Managed: in ServiceNow  
+Deployed: directly on the libserv97 VM (dev environment)  
 
-oar.princeton.edu
-Purpose: production site for oar
-Managed: Via [Lego](lego.md)
-Deployed: on Google cloud, on prod.pulcloud.io
+oar.princeton.edu  
+Purpose: production site for oar  
+Managed: Via [Lego](lego.md)  
+Deployed: on Google cloud, on prod.pulcloud.io  
 
-oar-dev.princeton.edu
-Purpose: production site for oar
-Managed: Via [Lego](lego.md)
-Deployed: on Google cloud, on prod.pulcloud.io
+oar-dev.princeton.edu  
+Purpose: production site for oar  
+Managed: Via [Lego](lego.md)  
+Deployed: on Google cloud, on prod.pulcloud.io  
 
-oar-staging.princeton.edu
-Purpose: production site for oar
-Managed: Via [Lego](lego.md)
-Deployed: on Google cloud, on prod.pulcloud.io
+oar-staging.princeton.edu  
+Purpose: staging site for oar  
+Managed: Via [Lego](lego.md)  
+Deployed: on Google cloud, on prod.pulcloud.io  
 
-pcdm.org
-Purpose: Portland Common Data Model
-Managed: [Lego](https://github.com/pulibrary/princeton_ansible/blob/main/roles/nginxplus/tasks/lego.yml)
+pcdm.org  
+Purpose: Portland Common Data Model  
+Managed: [Lego](https://github.com/pulibrary/princeton_ansible/blob/main/roles/nginxplus/tasks/lego.yml)  
 
-pulmirror.princeton.edu
-Purpose: distributing Ubuntu packages
-Managed: Via [Lego](lego.md)
-Deployed: on Google cloud at pulmirror.princeton.edu
+pulmirror.princeton.edu  
+Purpose: distributing Ubuntu packages  
+Managed: Via [Lego](lego.md)  
+Deployed: on Google cloud at pulmirror.princeton.edu  
 
-recapgfa.princeton.edu
-Purpose: ReCAP inventory management system
-Managed: by ACME directly on the VM
-Deployed: N/A - it automatically renews
+recapgfa.princeton.edu  
+Purpose: ReCAP inventory management system  
+Managed: by ACME directly on the VM  
+Deployed: N/A - it automatically renews  
 
-simrisk.pulcloud.io
-Purpose: experimental application for CDH
-Managed: on staging.pulcloud.io by acme-client contacting letsencrypt CA
-Deployed: in /etc/ssl/simrisk.pulcloud.io.fullchain.pem on the staging.pulcloud.io server
+simrisk.pulcloud.io  
+Purpose: experimental application for CDH  
+Managed: on staging.pulcloud.io by acme-client contacting letsencrypt CA  
+Deployed: in /etc/ssl/simrisk.pulcloud.io.fullchain.pem on the staging.pulcloud.io server  
 Maintained using `/etc/daily.local` as root
 
-tigris.princeton.edu
-Purpose: hosted service for University Records management
-Managed: in ServiceNow, private key is in princeton_ansible
-Deployed: by vendor; to update, email a .pfx file of the cert to support@gimmal.com
+tigris.princeton.edu  
+Purpose: hosted service for University Records management  
+Managed: in ServiceNow, private key is in princeton_ansible  
+Deployed: by vendor; to update, email a .pfx file of the cert to support@gimmal.com  
 
 #### Tigris
 


### PR DESCRIPTION
This looks like a huge change-set, but it actually just adds whitespace at the ends of lines for markdown management.

Also corrects some copy-pasta. 