### PR TITLE
adds helpful links to ServiceNow docs

### DIFF
--- a/services/service_now.md
+++ b/services/service_now.md
@@ -2,9 +2,9 @@
 
 ## Useful links
 
-[Unassigned tickets for Ops](https://princeton.service-now.com/now/nav/ui/classic/params/target/task_list.do%3Fsysparm_query%3Dassignment_group%253Ddfef0cf74f800b40b1eaf7e18110c7c1%255Eactive%253Dtrue%255Eassigned_to%253D%26sysparm_first_row%3D1%26sysparm_view%3D) - for "grabbing" tickets
-[Generic Request Form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=d93521720fcf820033f465ba32050ee5) - for creating new tickets
-[List of all network objects](https://princeton.service-now.com/now/nav/ui/classic/params/target/u_infoblox_networks_list.do%3Fsysparm_userpref_module%3D62d2d4244ff85f00f56c0ad14210c7c4%26sysparm_query%3Doperational_status%253D1%255EEQ) - for finding IP ranges
+- [Unassigned tickets for Ops](https://princeton.service-now.com/now/nav/ui/classic/params/target/task_list.do%3Fsysparm_query%3Dassignment_group%253Ddfef0cf74f800b40b1eaf7e18110c7c1%255Eactive%253Dtrue%255Eassigned_to%253D%26sysparm_first_row%3D1%26sysparm_view%3D) - for "grabbing" tickets
+- [Generic Request Form](https://princeton.service-now.com/service?id=sc_cat_item&sys_id=d93521720fcf820033f465ba32050ee5) - for creating new tickets
+- [List of all network objects](https://princeton.service-now.com/now/nav/ui/classic/params/target/u_infoblox_networks_list.do%3Fsysparm_userpref_module%3D62d2d4244ff85f00f56c0ad14210c7c4%26sysparm_query%3Doperational_status%253D1%255EEQ) - for finding IP ranges
 
 ## ServiceNow views
 


### PR DESCRIPTION
The ops team recently did a skillsharing session about how to 'grab' unassigned servicenow tickets. This PR adds some useful links that came out of that discussion, for Future Us.