### PR TITLE
[SSL certs] removes dev sites and libimages2, adds openpublishing site

### DIFF
--- a/services/create_ssl_certs.md
+++ b/services/create_ssl_certs.md
@@ -50,8 +50,6 @@ Many of these certs must be deployed manually. Some must also be renewed manuall
 
 If a private key is kept in princeton_ansible, it is encrypted as a file in the `/keys/` directory of the repo.
 
-DNSimple currently only allows one MFA connection. If you need to log into DNSimple, ping Francis for more information.
-
 Here is the current list:
 
 cicognara.org
@@ -113,6 +111,7 @@ openpublishing.princeton.edu
   * Managed: on DNSimple and Vendor's AWS Certificate Manager
   * Deployed: by vendor (Notch8) and CNAME validation on DNSimple
   * If ever there is a change in the application vendor will provide CNAME which can be added to DNSimple configuration
+  * NOTE: DNSimple currently only allows one MFA connection. If you need to log into DNSimple, ping Francis for more information.
 
 pcdm.org
   * Purpose: Portland Common Data Model
@@ -134,6 +133,7 @@ scsb.recaplib.org
   * Managed: on DNSimple and Vendor's AWS Certificate Manager
   * Deployed: by vendor and CNAME validation on DNSimple
   * If ever there is a change in the application vendor will provide CNAME which can be added to DNSimple configuration
+  * NOTE: DNSimple currently only allows one MFA connection. If you need to log into DNSimple, ping Francis for more information.
 
 simrisk.pulcloud.io
   * Purpose: experimental application for CDH

--- a/services/create_ssl_certs.md
+++ b/services/create_ssl_certs.md
@@ -50,6 +50,8 @@ Many of these certs must be deployed manually. Some must also be renewed manuall
 
 If a private key is kept in princeton_ansible, it is encrypted as a file in the `/keys/` directory of the repo.
 
+DNSimple currently only allows one MFA connection. If you need to log into DNSimple, ping Francis for more information.
+
 Here is the current list:
 
 cicognara.org
@@ -61,11 +63,6 @@ dataspace.princeton.edu
   * Purpose: production site for dspace
   * Managed: Via [Lego](lego.md)
   * Deployed: on Google cloud, on prod.pulcloud.io
-
-dataspace-dev.princeton.edu
-  * Purpose: dev/staging site for dspace
-  * Managed: Via [Lego](lego.md)
-  * Deployed: on Google cloud, on dev.pulcloud.io
 
 dataspace-staging.princeton.edu
   * Purpose: dev/staging site for dspace
@@ -82,9 +79,6 @@ ezproxy.princeton.edu
   * Purpose: allows access to journals by confirming Princeton affiliation
   * Managed: on ezproxy-prod1 by letsencrypt
   * Deployed: in /etc/letsencrypt/live/ezproxy on the ezproxy-prod1 server
-
-imagecat2.princeton.edu
-  * Philippe will shut down the server once he has copied whatever we need from it. Once it's gone, we can revoke the cert.
 
 lib-aeon.princeton.edu
   * Purpose: redirects traffic to hosted Aeon service at <https://princeton.aeon.atlas-sys.com>
@@ -114,15 +108,16 @@ oar.princeton.edu
   * Managed: Via [Lego](lego.md)
   * Deployed: on Google cloud, on prod.pulcloud.io
 
-oar-dev.princeton.edu
-  * Purpose: production site for oar
-  * Managed: Via [Lego](lego.md)
-  * Deployed: on Google cloud, on prod.pulcloud.io
-
 oar-staging.princeton.edu
   * Purpose: production site for oar
   * Managed: Via [Lego](lego.md)
   * Deployed: on Google cloud, on prod.pulcloud.io
+
+openpublishing.princeton.edu
+  * Purpose: external hosted service for open access to scholarly work
+  * Managed: on DNSimple and Vendor's AWS Certificate Manager
+  * Deployed: by vendor (Notch8) and CNAME validation on DNSimple
+  * If ever there is a change in the application vendor will provide CNAME which can be added to DNSimple configuration
 
 pcdm.org
   * Purpose: Portland Common Data Model

--- a/services/create_ssl_certs.md
+++ b/services/create_ssl_certs.md
@@ -98,11 +98,6 @@ lib-illsql.princeton.edu
   * Deployed: in IIS, on the lib-illiad-new VM
   * Notes: Windows VM; cert has a SAN name of lib-illiad.princeton.edu; we hope to migrate this to a hosted platform in 2024
 
-libserv97.princeton.edu
-  * Purpose: Philippe's test machine, may disappear in 2024
-  * Managed: in ServiceNow
-  * Deployed: directly on the libserv97 VM (dev environment)
-
 oar.princeton.edu
   * Purpose: production site for oar
   * Managed: Via [Lego](lego.md)


### PR DESCRIPTION
We have recently decommissioned a couple of sites and migrated another site to a hosted platform. 

This PR updates the documentation for SSL certs that do not run on the load balancers.
- removes dataspace-dev (see https://github.com/pulibrary/princeton_ansible/issues/6782)
- removes oar-dev (see https://github.com/pulibrary/princeton_ansible/issues/6783)
- removes imagecat2
- removes libserv97 (see https://gitlab.lib.princeton.edu/ops/team-handbook/-/work_items/173)
- adds openpublishing (see https://gitlab.lib.princeton.edu/ops/team-handbook/-/work_items/328)
- adds a note about DNSimple access